### PR TITLE
Improve configuration of how SQL scripts are located

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -156,18 +156,28 @@ Rules for the file are:
 
 === How the module locates SQL script files
 
-There are two ways SQL scripts are located by Pre-Liquibase:
+Pre-Liquibase locates the SQL script(s) to execute based on the value of the `sqlScriptReferences` 
+configuration property. The default for this property is `classpath:/preliquibase/`.
 
-1. From classpath: If a file named `preliquibase/DBPLATFORMCODE.sql` exists it will be executed. DBPLATFORMCODE is a string code 
-representing the type of database in use. The module will auto-detect the database platform, but you can optionally override 
-the value with the `dbPlatformCode` configuration property. If no such file `preliquibase/DBPLATFORMCODE.sql` file exists the
-module will execute a file named `preliquibase/default.sql` if it exists.
+In general, `sqlScriptReferences` is interpreted as a comma-separated list of 
+https://docs.spring.io/spring-framework/docs/current/reference/html/core.html#resources-resource-strings[Spring Resource textual
+references]. It can be configured to either "folder mode" or "file mode":
 
-2. If the property `sqlScriptReferences` has been set then that takes precedence over (1). The value of this property is expected
-to be a comma-separated list of https://docs.spring.io/spring-framework/docs/current/reference/html/core.html#resources-resource-strings[Spring Resource references]
-to SQL script files. All of the SQL script files in the list will be executed, in the order they are listed.
 
-NOTE: The way SQL script files are located and named is heavily inspired by 
+1. Folder mode: Configure `sqlScriptReferences` to a single value ending in the "/" character.
+In this mode the value will be interpreted as a folder location where SQL scripts to be executed
+are found. From this folder, if a file named `preliquibase/DBPLATFORMCODE.sql` exists, it will be executed. 
+`DBPLATFORMCODE` is a string code representing the type of database in use. The module will <<auto_detection,auto-detect>>
+the database platform,  but you can optionally override the value with the `dbPlatformCode` configuration property. If no such file 
+`preliquibase/DBPLATFORMCODE.sql` file exists the module will execute a file named `preliquibase/default.sql` if it exists.
+If neither such file exists in the folder then no action will be taken (not an error).
+
+2. File mode: Configure `sqlScriptReferences` to be a comma-separated list of individual SQL script files.
+All of the SQL script files in the list will be executed, in the order they are listed.
+Prior to execution of any SQL script file it is checked if all files mentioned actually exist, if not
+a `PreLiquibaseException.SqlScriptRefError` is thrown.
+
+NOTE: The way SQL script files are located and named is somewhat inspired by 
 https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-initialize-a-database-using-spring-jdbc[Spring Boot's DataSource Initialization feature]. 
 However, there are some important differences: Pre-Liquibase auto-detects which database platform you are using and secondly if a platform 
 specific SQL script file is found then Pre-Liquibase will not attempt to _also_ execute the platform generic file (`default.sql`).

--- a/autoconfigure/pom.xml
+++ b/autoconfigure/pom.xml
@@ -33,6 +33,10 @@ limitations under the License.
             <artifactId>spring-boot-starter-jdbc</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.liquibase</groupId>

--- a/autoconfigure/src/main/java/net/lbruun/springboot/preliquibase/PreLiquibaseException.java
+++ b/autoconfigure/src/main/java/net/lbruun/springboot/preliquibase/PreLiquibaseException.java
@@ -79,7 +79,7 @@ public abstract class PreLiquibaseException extends RuntimeException {
     }
     
     /**
-     * Thrown when location of SQL scripts are
+     * Thrown when location of individual SQL scripts are
      * {@link PreLiquibaseProperties#setSqlScriptReferences(java.util.List) explicitly specified}
      * and one or more of the references is invalid (file not found, incorrect
      * specification of Spring Resource reference, etc).

--- a/autoconfigure/src/main/java/net/lbruun/springboot/preliquibase/PreLiquibaseProperties.java
+++ b/autoconfigure/src/main/java/net/lbruun/springboot/preliquibase/PreLiquibaseProperties.java
@@ -17,33 +17,39 @@ package net.lbruun.springboot.preliquibase;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
+import javax.validation.constraints.NotEmpty;
 import static net.lbruun.springboot.preliquibase.PreLiquibaseProperties.PROPERTIES_PREFIX;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 /**
  * Properties for Pre-Liquibase module.
  * 
  * @author lbruun
  */
+@Validated
 @ConfigurationProperties(prefix = PROPERTIES_PREFIX)
 public class PreLiquibaseProperties {
 
     public static final String PROPERTIES_PREFIX = "preliquibase";
-    
+    public static final String DEFAULT_SCRIPT_LOCATION
+            = "classpath:preliquibase/";
     
     private boolean enabled = true;
     
     /**
      * Database platform code to use in the SQL scripts 
-     * (such as preliquibase-${dbPlatformCode}.sql). 
+     * (such as preliquibase/${dbPlatformCode}.sql). 
      */
     private String dbPlatformCode;
 
     /**
      * SQL script resource references.
      */
-    private List<String> sqlScriptReferences;
+    @NotEmpty(message="sqlScriptReferences must not be empty")
+    private List<String> sqlScriptReferences = Collections.singletonList(DEFAULT_SCRIPT_LOCATION);
 
     /**
      * Whether to stop if an error occurs while executing the SQL script.
@@ -62,7 +68,7 @@ public class PreLiquibaseProperties {
 
     
     /**
-     * Get the 'enabled' setting (ff the module is enabled or not).
+     * Get the 'enabled' setting (if the module is enabled or not).
      * @see #setEnabled(boolean) 
      * @return 
      */
@@ -90,7 +96,7 @@ public class PreLiquibaseProperties {
 
     /**
      * Sets whether to stop if an error occurs while executing the SQL script.
-     * Default to {@code false} if not set.
+     * Default value is: {@code false}.
      */
     public void setContinueOnError(boolean continueOnError) {
         this.continueOnError = continueOnError;
@@ -146,8 +152,8 @@ public class PreLiquibaseProperties {
     }
 
     /**
-     * Sets to the db engine code to use when finding which
-     * SQL script to execute, as in {@code preliquibase-${dbEngineCode}.sql}}
+     * Sets the db engine code to use when finding which
+     * SQL script to execute, as in {@code preliquibase/${dbEngineCode}.sql}}
      * 
      * <p>
      * Setting this value explicitly overrides the database platform
@@ -169,15 +175,41 @@ public class PreLiquibaseProperties {
     }
 
     /**
-     * Sets explicit locations of where to find the SQL script(s) 
-     * to execute, meaning rather than finding the SQL script(s) in 
-     * the default classpath location.
+     * Sets location(s) of where to find the SQL script(s) to execute.
      * 
      * <p>
-     * When expressed as a string value it must be a comma-separated list of Spring Resource references,
-     * for example {@code "file:/foo/bar/myscript1.sql,file:/foo/bar/myscript2.sql}.
-     * Each resource in the list must exist, otherwise an {@link PreLiquibaseException.SqlScriptRefError}
-     * exception is thrown.
+     * The value is interpreted slightly differently depending on its
+     * content:
+     * <ul>
+     *   <li>If the value is a Spring Resource textual reference which ends with {@code "/"}:
+     *       In this case, the reference is expected to be a folder reference
+     *       where SQL scripts can be found. From this folder:
+     *       If a file named "{@link #setDbPlatformCode(java.lang.String) 
+     *       DBPLATFORMCODE}{@code .sql}" (e.g. "{@code postgresql.sql}") exists then 
+     *       that will be used. If no such file is found then a file named 
+     *       "{@code default.sql}" is used. 
+     *       If neither file is found then no action will be taken, similarly
+     *       to {@link #setEnabled(boolean) disabling} the module.
+     *       <br>
+     *       Example values:<br>
+     *       {@code "classpath:my-folder/"} (load from classpath folder).<br>
+     *       {@code "file:c:/config/sql-scripts/"} (load from file system folder, Windows).<br>
+     *       {@code "file:/app/etc/sql-scripts/"} (load from file system folder, Linux).<br>
+     *       <br>
+     *   </li>
+     *   <li>Otherwise: The value is interpreted as a comma-separated list of 
+     *       Spring Resource textual references to <i>specific</i> SQL files. Each 
+     *       script file will be executed in the order they are listed. Before
+     *       execution of any of of the script files it is checked if all files
+     *       mentioned in the list actually exists. If not, an 
+     *       {@link PreLiquibaseException.SqlScriptRefError} exception is thrown.
+     *       <br>
+     *       Example value: {@code "file:/foo/bar/myscript1.sql,file:/foo/bar/myscript2.sql"}.
+     *   </li>
+     * </ul>
+     * 
+     * <p>
+     * Default value: {@link #DEFAULT_SCRIPT_LOCATION}.
      * 
      * @param sqlScriptReferences list of Spring Resource references.
      */


### PR DESCRIPTION
This PR adds the ability to use "folder-based" specification of SQL scripts (meaning where scripts are selected for execution based on their file name, i.e. database engine specific scripts, such as `postgresql.sql`), even with a custom location.

The change is backwards compatible.