### PR TITLE
Autoconfiguration file for Spring Boot 2.7+ / Required by Spring Boot 3

### DIFF
--- a/autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+# Add Pre-Liquibase class to list of Spring Boot's auto-configurations
+net.lbruun.springboot.preliquibase.PreLiquibaseAutoConfiguration


### PR DESCRIPTION
Spring Boot 3 will not support
org.springframework.boot.autoconfigure.EnableAutoConfiguration in spring.factories

See: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#auto-configuration-registration
See: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0.0-M5-Release-Notes#auto-configuration-registration