### PR TITLE
Simplify getLiquibaseDatabaseShortname method

### DIFF
--- a/autoconfigure/src/main/java/net/lbruun/springboot/preliquibase/utils/LiquibaseUtils.java
+++ b/autoconfigure/src/main/java/net/lbruun/springboot/preliquibase/utils/LiquibaseUtils.java
@@ -73,6 +73,11 @@ public class LiquibaseUtils {
      * connection used to determine the database type is closed again before the
      * method exits.
      *
+     * <p>
+     * Note that this is a fairly heavy operation as it involves a round-trip to the
+     * database. As the information does not change it is best to use this method
+     * only once and then cache the result.
+     *
      * @param dataSource input
      * @return Liquibase database shortname, always lower case, never null;
      * @throws PreLiquibaseException.ResolveDbPlatformError on all kinds of errors

--- a/autoconfigure/src/main/java/net/lbruun/springboot/preliquibase/utils/LiquibaseUtils.java
+++ b/autoconfigure/src/main/java/net/lbruun/springboot/preliquibase/utils/LiquibaseUtils.java
@@ -31,10 +31,8 @@ import java.sql.SQLException;
  */
 public class LiquibaseUtils {
 
-
     private LiquibaseUtils() {
     }
-
 
     /**
      * Finds the Liquibase database {@code shortname} for a DataSource.
@@ -95,5 +93,4 @@ public class LiquibaseUtils {
             throw new PreLiquibaseException.ResolveDbPlatformError("Unexpected error while finding Liquibase Database implementation for DataSource", ex3);
         }
     }
-
 }


### PR DESCRIPTION
Since Liquibase v4.14.0 the `Autocloseable` interface has been added to Liquibase `JdbcConnection` and Liquibase `Database` classes.  This allows our method, `getLiquibaseDatabaseShortname()`, to be greatly simplified.

Thanks to [zorglube](https://github.com/zorglube) for making this possible.
    
