### PR TITLE
Spring Boot 3.1 compatibility

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -38,7 +38,7 @@ If not, you should pause and ask yourself if you are doing the right thing.
 The module requires 
 
 - Java 17 or later (artifacts before `1.3` only require Java 8 but do not support Spring Boot 3)
-- Spring Boot 3.0 or later (for older versions see <<Spring Boot compatibility>>)
+- Spring Boot 3.1 or later (for older versions see <<Spring Boot compatibility>>)
 
 {nbsp} +
 {nbsp} +
@@ -354,7 +354,7 @@ easily adapt to a single datasource use-case.
 
 == Spring Boot compatibility
 
-Current version works with Spring Boot 3.0+ and has been tested with version 3.0. There's no reason why it
+Current version works with Spring Boot 3.1+ and has been tested with version 3.1. There's no reason why it
 should not work with any future 3.x release of Spring Boot.
 
 
@@ -366,11 +366,17 @@ should not work with any future 3.x release of Spring Boot.
 |Git branch name
 |Description
 
-|1.3.x
-|Spring Boot 3.0
+|1.4.x
+|Spring Boot 3.1
 |JDK 17
 |`master`
 |Use this unless you absolutely *must* use an older version of Spring Boot.
+
+|1.3.x
+|Spring Boot 3.0
+|JDK 17
+|
+|No longer maintained
 
 |1.2.x
 |Spring Boot 2.6 and 2.7

--- a/autoconfigure/src/main/java/net/lbruun/springboot/preliquibase/PreLiquibaseAutoConfiguration.java
+++ b/autoconfigure/src/main/java/net/lbruun/springboot/preliquibase/PreLiquibaseAutoConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.boot.autoconfigure.condition.*;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseConnectionDetails;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseDataSource;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -69,11 +70,12 @@ public class PreLiquibaseAutoConfiguration {
             LiquibaseProperties liquibaseProperties,
             DataSourceProperties dataSourceProperties,
             ObjectProvider<DataSource> dataSource,
-            @LiquibaseDataSource ObjectProvider<DataSource> liquibaseDataSource) {
+            @LiquibaseDataSource ObjectProvider<DataSource> liquibaseDataSource,
+            LiquibaseConnectionDetails connectionDetails) {
         logger.debug("Instantiation of PreLiquibaseDataSourceProvider");
 
         return new DefaultPreLiquibaseDataSourceProvider(
-                liquibaseProperties, dataSourceProperties, dataSource, liquibaseDataSource);
+                liquibaseProperties, dataSourceProperties, dataSource, liquibaseDataSource, connectionDetails);
     }
 
     /**
@@ -195,7 +197,8 @@ public class PreLiquibaseAutoConfiguration {
                 @NonNull LiquibaseProperties liquibaseProperties,
                 @NonNull DataSourceProperties dataSourceProperties,
                 @NonNull ObjectProvider<DataSource> dataSource,
-                @NonNull ObjectProvider<DataSource> liquibaseDataSource) {
+                @NonNull ObjectProvider<DataSource> liquibaseDataSource,
+                @NonNull LiquibaseConnectionDetails connectionDetails) {
 
             // Here we re-use Spring Boot's own LiquibaseAutoConfiguration
             // so that we figure out which DataSource will (later) be used
@@ -207,9 +210,9 @@ public class PreLiquibaseAutoConfiguration {
             // afterPropertiesSet method to kick in. All we are interested in 
             // is to figure out which datasource Liquibase would be using.
             LiquibaseAutoConfiguration.LiquibaseConfiguration liquibaseConfiguration
-                    = new LiquibaseAutoConfiguration.LiquibaseConfiguration(liquibaseProperties);
+                    = new LiquibaseAutoConfiguration.LiquibaseConfiguration();
             SpringLiquibase liquibase = liquibaseConfiguration.liquibase(
-                    dataSource, liquibaseDataSource);
+                    dataSource, liquibaseDataSource, liquibaseProperties, connectionDetails);
 
             // Sanity check
             Objects.requireNonNull(liquibase.getDataSource(), "Unexpected: null value for DataSource returned from SpringLiquibase class");

--- a/examples/example1/pom.xml
+++ b/examples/example1/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
     <groupId>net.lbruun.springboot</groupId>

--- a/examples/example2/pom.xml
+++ b/examples/example2/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
     <groupId>net.lbruun.springboot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.scm.id>github.com-lbruun.net</project.scm.id>
-        <spring.boot.version>3.0.0</spring.boot.version>
+        <spring.boot.version>3.1.0</spring.boot.version>
     </properties>
 
     <url>https://github.com/lbruun/Pre-Liquibase</url>


### PR DESCRIPTION
org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration changed in a backwards incompatible way in Spring Boot 3.1.

See: https://github.com/spring-projects/spring-boot/commit/d4980ea9931c6f48641dd0316d1b1737a50a4a7a
See: https://github.com/spring-projects/spring-boot/issues/34776