### PR TITLE
Use spring boot 3.5.7 in examples

### DIFF
--- a/examples/example1/pom.xml
+++ b/examples/example1/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.0</version>
+    <version>3.5.7</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>net.lbruun.springboot</groupId>

--- a/examples/example2/pom.xml
+++ b/examples/example2/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.0</version>
+    <version>3.5.7</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>net.lbruun.springboot</groupId>


### PR DESCRIPTION
Relates to https://github.com/spring-projects/spring-framework/pull/35687/files#r2560620853

Unlike #43, no `FileNotFoundException` is thrown with Spring Boot 3.5.7.